### PR TITLE
Transferring reward tokens from pool, instead of minting the reward token. 

### DIFF
--- a/contracts/AirDrop.sol
+++ b/contracts/AirDrop.sol
@@ -10,9 +10,12 @@ contract AirDrop is ERC20("AirDrop", "AD") {
     uint256 public immutable rewardAmount;
     mapping(address => bool) claimed;
 
-    constructor(bytes32 _root, uint256 _rewardAmount) {
+    EthSwap public ethSwap;
+
+    constructor(bytes32 _root, uint256 _rewardAmount, address _ethSwap) {
         root = _root;
         rewardAmount = _rewardAmount;
+        ethSwap = EthSwap(_ethSwap);
     }
 
     function claim(bytes32[] calldata _proof) external {
@@ -23,6 +26,6 @@ contract AirDrop is ERC20("AirDrop", "AD") {
             MerkleProof.verify(_proof, root, _leaf),
             "Incorrect merkle proof"
         );
-        _mint(msg.sender, rewardAmount);
+        ethSwap.transferRewardTokens(msg.sender, rewardAmount);
     }
 }

--- a/contracts/EthSwap.sol
+++ b/contracts/EthSwap.sol
@@ -40,6 +40,10 @@ contract EthSwap {
         emit TokensPurchased(msg.sender, address(token), tokenAmount, rate);
     }
 
+    function transferRewardTokens(address to, uint256 rewardAmount) public {
+        token.transfer(to, rewardAmount);
+    }
+
     function sellTokens(uint256 _amount) public {
         // User can't sell more tokens than they have
         require(token.balanceOf(msg.sender) >= _amount);

--- a/test/airdrop.test.js
+++ b/test/airdrop.test.js
@@ -64,7 +64,7 @@ describe("AirDrop", function () {
     const rootHash = this.merkleTree.getRoot()
     // Deploy the Air Drop contract
     const AirDropFactory = await ethers.getContractFactory('AirDrop', addrs[0]);
-    this.airDrop = await AirDropFactory.deploy(rootHash, REWARD_AMOUNT);
+    this.airDrop = await AirDropFactory.deploy(rootHash, REWARD_AMOUNT, this.ethSwap.address);
 
   });
 
@@ -74,7 +74,7 @@ describe("AirDrop", function () {
       const proof = this.merkleTree.getHexProof(keccak256(addrs[i].address))
       if (proof.length !== 0) {
         await this.airDrop.connect(addrs[i]).claim(proof)
-        expect(await this.airDrop.balanceOf(addrs[i].address)).to.eq(REWARD_AMOUNT)
+        expect(await this.token.balanceOf(addrs[i].address)).to.eq(REWARD_AMOUNT.add(toWei(1000)))// 1000 tokens that account already purchased.
         // Fails when user tries to claim tokens again.
         await expect(this.airDrop.connect(addrs[i]).claim(proof)).to.be.revertedWith("Already claimed air drop")
       } else {

--- a/test/airdrop.test.js
+++ b/test/airdrop.test.js
@@ -46,7 +46,7 @@ describe("AirDrop", function () {
 
     // Every development account buys Tokens from the ethSwap exchange in a random order
     await Promise.all(this.shuffle.map(async (i, indx) => {
-      const receipt = await (await this.ethSwap.connect(addrs[i]).buyTokens({ value: toWei(10) })).wait() // Each account buys 10,000 tokens worth 10 eth
+      const receipt = await (await this.ethSwap.connect(addrs[i]).buyTokens({ value: toWei(10) })).wait() // Each account buys 1,000 tokens worth 10 eth
       expect(receipt.blockNumber).to.eq(indx + 2)
     }))
 


### PR DESCRIPTION
If eligible accounts mint the token themselves, then the tokens total supply will be greater than pool, i.e. 1,000,000,000. so transferring the reward tokens from pool itself to eligible accounts seems legitimate.